### PR TITLE
Update version handling and remove version field from example configuration

### DIFF
--- a/.github/workflows/release-go-github.yml
+++ b/.github/workflows/release-go-github.yml
@@ -45,6 +45,7 @@ jobs:
         goarch: ${{ matrix.goarch }}
         project_path: "./"
         binary_name: ${{ github.event.repository.name }}
+        ldflags: "-X 'main.Version=${{ github.ref_name }}'"
         md5sum: true
         sha256sum: true
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ The configuration folder uses a special configuration file `forge.yaml` that spe
 The following attributes can be specified in the file:
 
 - `name`: The name of the MCP server
-- `version`: The version of the MCP server
 - `url`: The URL of the GraphQL endpoint
 - `token_command`: The command to use to request the Bearer token for the `Authorization` header (optional)
 - `env`: A map of environment variables to pass to the token command (optional)
@@ -34,7 +33,6 @@ An example configuration would look like:
 
 ```yaml
 name: "ExampleServer"
-version: "0.1.0"
 url: "https://api.github.com/graphql"
 token_command: "gh auth token"
 ```

--- a/example/forge.yaml
+++ b/example/forge.yaml
@@ -1,6 +1,5 @@
 # forge.yaml
 name: "ExampleServer"
-version: "0.1.0"
 url: "https://api.github.com/graphql"
 token_command: "gh auth token"
 

--- a/main.go
+++ b/main.go
@@ -23,10 +23,11 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
+var Version = "dev" // This will be set by the build systems to the release version
+
 // ForgeConfig holds global server settings
 type ForgeConfig struct {
 	Name           string            `yaml:"name"`
-	Version        string            `yaml:"version"`
 	URL            string            `yaml:"url"`
 	TokenCommand   string            `yaml:"token_command"`
 	Env            map[string]string `yaml:"env,omitempty"`
@@ -239,7 +240,7 @@ func main() {
 	}
 
 	// Init MCP server
-	srv := server.NewMCPServer(cfg.Name, cfg.Version)
+	srv := server.NewMCPServer(cfg.Name, Version)
 
 	// Discover & register tools
 	files, err := filepath.Glob(filepath.Join(configDir, "*.yaml"))


### PR DESCRIPTION
- Set version variable in main.go to be populated during build
- Update release-go-github.yml to include ldflags for versioning
- Remove version attribute from README and example forge.yaml